### PR TITLE
fixed readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@
     MAIL_USERNAME=mailusername
     MAIL_PW=mailpassword
     ADMIN_IP=11.12.13.14
-    BASE=mydomain.com/
+    BASE=mydomain.com
     DISCORD_CID=
     DISCORD_TOKEN=


### PR DESCRIPTION
Removed a misleading slash from `BASE` definition.
With the slash included, the issue resulted in sending an incorrect url in the verification e-mail. Incorrect url led to a 404 error page.